### PR TITLE
fix file handle leak in sumTypeDeclSearch

### DIFF
--- a/decl.go
+++ b/decl.go
@@ -62,6 +62,7 @@ func sumTypeDeclSearch(path string) ([]sumTypeDecl, error) {
 	if err != nil {
 		return nil, err
 	}
+	defer f.Close()
 	lineNum := 0
 	scanner := bufio.NewScanner(f)
 	for scanner.Scan() {


### PR DESCRIPTION
The tests fail on windows because the generated src.go files are still open