### PR TITLE
Go modules support

### DIFF
--- a/check_test.go
+++ b/check_test.go
@@ -27,10 +27,10 @@ func main() {
 	}
 }
 `
-	tmpdir, prog := setupPackage(t, code)
+	tmpdir, pkg := setupPackage(t, code)
 	defer teardownPackage(t, tmpdir)
 
-	errs := run(prog)
+	errs := run(pkg)
 	if !assert.Len(t, errs, 1) {
 		t.FailNow()
 	}
@@ -61,10 +61,10 @@ func main() {
 	}
 }
 `
-	tmpdir, prog := setupPackage(t, code)
+	tmpdir, pkg := setupPackage(t, code)
 	defer teardownPackage(t, tmpdir)
 
-	errs := run(prog)
+	errs := run(pkg)
 	if !assert.Len(t, errs, 1) {
 		t.FailNow()
 	}
@@ -95,10 +95,10 @@ func main() {
 	}
 }
 `
-	tmpdir, prog := setupPackage(t, code)
+	tmpdir, pkg := setupPackage(t, code)
 	defer teardownPackage(t, tmpdir)
 
-	errs := run(prog)
+	errs := run(pkg)
 	if !assert.Len(t, errs, 1) {
 		t.FailNow()
 	}
@@ -129,10 +129,10 @@ func main() {
 	}
 }
 `
-	tmpdir, prog := setupPackage(t, code)
+	tmpdir, pkg := setupPackage(t, code)
 	defer teardownPackage(t, tmpdir)
 
-	errs := run(prog)
+	errs := run(pkg)
 	assert.Len(t, errs, 0)
 }
 
@@ -160,10 +160,10 @@ func main() {
 	}
 }
 `
-	tmpdir, prog := setupPackage(t, code)
+	tmpdir, pkg := setupPackage(t, code)
 	defer teardownPackage(t, tmpdir)
 
-	errs := run(prog)
+	errs := run(pkg)
 	assert.Len(t, errs, 0)
 }
 
@@ -179,10 +179,10 @@ type T interface {}
 
 func main() {}
 `
-	tmpdir, prog := setupPackage(t, code)
+	tmpdir, pkg := setupPackage(t, code)
 	defer teardownPackage(t, tmpdir)
 
-	errs := run(prog)
+	errs := run(pkg)
 	if !assert.Len(t, errs, 1) {
 		t.FailNow()
 	}
@@ -199,10 +199,10 @@ package main
 
 func main() {}
 `
-	tmpdir, prog := setupPackage(t, code)
+	tmpdir, pkg := setupPackage(t, code)
 	defer teardownPackage(t, tmpdir)
 
-	errs := run(prog)
+	errs := run(pkg)
 	if !assert.Len(t, errs, 1) {
 		t.FailNow()
 	}
@@ -221,10 +221,10 @@ type T struct {}
 
 func main() {}
 `
-	tmpdir, prog := setupPackage(t, code)
+	tmpdir, pkg := setupPackage(t, code)
 	defer teardownPackage(t, tmpdir)
 
-	errs := run(prog)
+	errs := run(pkg)
 	if !assert.Len(t, errs, 1) {
 		t.FailNow()
 	}

--- a/def.go
+++ b/def.go
@@ -5,7 +5,7 @@ import (
 	"go/ast"
 	"go/types"
 
-	"golang.org/x/tools/go/loader"
+	"golang.org/x/tools/go/packages"
 )
 
 // unsealedError corresponds to a declared sum type whose interface is not
@@ -53,11 +53,11 @@ type sumTypeDef struct {
 // findSumTypeDefs attempts to find a Go type definition for each of the given
 // sum type declarations. If no such sum type definition could be found for
 // any of the given declarations, then an error is returned.
-func findSumTypeDefs(prog *loader.Program, decls []sumTypeDecl) ([]sumTypeDef, []error) {
+func findSumTypeDefs(pkg *packages.Package, decls []sumTypeDecl) ([]sumTypeDef, []error) {
 	var defs []sumTypeDef
 	var errs []error
 	for _, decl := range decls {
-		def, err := newSumTypeDef(decl.PackageInfo.Pkg, decl)
+		def, err := newSumTypeDef(decl.Package.Types, decl)
 		if err != nil {
 			errs = append(errs, err)
 			continue

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,8 @@
+module github.com/BurntSushi/go-sumtype
+
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/stretchr/testify v1.2.2
+	golang.org/x/tools v0.0.0-20181112210238-4b1f3b6b1646
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,8 @@
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/testify v1.2.2 h1:bSDNvY7ZPG5RlJ8otE/7V6gMiyenm9RtJ7IUVIAoJ1w=
+github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
+golang.org/x/tools v0.0.0-20181112210238-4b1f3b6b1646 h1:JEEoTsNEpPwxsebhPLC6P2jNr+6RFZLY4elUBVcMb+I=
+golang.org/x/tools v0.0.0-20181112210238-4b1f3b6b1646/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=

--- a/help_test.go
+++ b/help_test.go
@@ -6,10 +6,10 @@ import (
 	"path/filepath"
 	"testing"
 
-	"golang.org/x/tools/go/loader"
+	"golang.org/x/tools/go/packages"
 )
 
-func setupPackage(t *testing.T, code string) (string, *loader.Program) {
+func setupPackage(t *testing.T, code string) (string, *packages.Package) {
 	tmpdir, err := ioutil.TempDir("", "go-test-sumtype-")
 	if err != nil {
 		t.Fatal(err)
@@ -18,11 +18,17 @@ func setupPackage(t *testing.T, code string) (string, *loader.Program) {
 	if err := ioutil.WriteFile(srcPath, []byte(code), 0666); err != nil {
 		t.Fatal(err)
 	}
-	prog, err := tycheckAll([]string{srcPath})
-	if err != nil {
-		t.Fatal(err)
+	pkgs, errs := loadPackages([]string{srcPath})
+	if len(errs) > 0 {
+		t.Fatal(errs[0])
 	}
-	return tmpdir, prog
+	if len(pkgs) == 0 {
+		t.Fatal("no packages returned by loadPackages()")
+	}
+	if len(pkgs) > 1 {
+		t.Fatal("more than one package returned by loadPackages()")
+	}
+	return tmpdir, pkgs[0]
 }
 
 func teardownPackage(t *testing.T, dir string) {


### PR DESCRIPTION
This uses the new package `golang.org/x/tools/go/packages` instead of `golang.org/x/tools/go/loader` to load code, so that we can support checking packages that use Go modules with Go >= 1.11. This fixes #8.

I'm not sure the change in command line usage breaks anything, though the semantics are changed, because `go/packages` works a bit differently from `go/loader`. The former now takes a set of files and patterns in order to resolve Go packages. The way I did it, `go-sumtype myfile.go` still works, and `go-sumtype ./mypkg/subpkg/...` also works, without having to invoke `go list`, so this is technically an improvement. If you think this is too magical, it's possible that we could revert to the old behaviour, but I don't think so.

I added a `go.mod` file for good measure.