### PR TITLE
Go modules support

### DIFF
--- a/check_test.go
+++ b/check_test.go
@@ -27,10 +27,10 @@ func main() {
 	}
 }
 `
-	tmpdir, prog := setupPackage(t, code)
+	tmpdir, pkgs := setupPackages(t, code)
 	defer teardownPackage(t, tmpdir)
 
-	errs := run(prog)
+	errs := run(pkgs)
 	if !assert.Len(t, errs, 1) {
 		t.FailNow()
 	}
@@ -61,10 +61,10 @@ func main() {
 	}
 }
 `
-	tmpdir, prog := setupPackage(t, code)
+	tmpdir, pkgs := setupPackages(t, code)
 	defer teardownPackage(t, tmpdir)
 
-	errs := run(prog)
+	errs := run(pkgs)
 	if !assert.Len(t, errs, 1) {
 		t.FailNow()
 	}
@@ -95,10 +95,10 @@ func main() {
 	}
 }
 `
-	tmpdir, prog := setupPackage(t, code)
+	tmpdir, pkgs := setupPackages(t, code)
 	defer teardownPackage(t, tmpdir)
 
-	errs := run(prog)
+	errs := run(pkgs)
 	if !assert.Len(t, errs, 1) {
 		t.FailNow()
 	}
@@ -129,10 +129,10 @@ func main() {
 	}
 }
 `
-	tmpdir, prog := setupPackage(t, code)
+	tmpdir, pkgs := setupPackages(t, code)
 	defer teardownPackage(t, tmpdir)
 
-	errs := run(prog)
+	errs := run(pkgs)
 	assert.Len(t, errs, 0)
 }
 
@@ -160,10 +160,10 @@ func main() {
 	}
 }
 `
-	tmpdir, prog := setupPackage(t, code)
+	tmpdir, pkgs := setupPackages(t, code)
 	defer teardownPackage(t, tmpdir)
 
-	errs := run(prog)
+	errs := run(pkgs)
 	assert.Len(t, errs, 0)
 }
 
@@ -179,10 +179,10 @@ type T interface {}
 
 func main() {}
 `
-	tmpdir, prog := setupPackage(t, code)
+	tmpdir, pkgs := setupPackages(t, code)
 	defer teardownPackage(t, tmpdir)
 
-	errs := run(prog)
+	errs := run(pkgs)
 	if !assert.Len(t, errs, 1) {
 		t.FailNow()
 	}
@@ -199,10 +199,10 @@ package main
 
 func main() {}
 `
-	tmpdir, prog := setupPackage(t, code)
+	tmpdir, pkgs := setupPackages(t, code)
 	defer teardownPackage(t, tmpdir)
 
-	errs := run(prog)
+	errs := run(pkgs)
 	if !assert.Len(t, errs, 1) {
 		t.FailNow()
 	}
@@ -221,10 +221,10 @@ type T struct {}
 
 func main() {}
 `
-	tmpdir, prog := setupPackage(t, code)
+	tmpdir, pkgs := setupPackages(t, code)
 	defer teardownPackage(t, tmpdir)
 
-	errs := run(prog)
+	errs := run(pkgs)
 	if !assert.Len(t, errs, 1) {
 		t.FailNow()
 	}

--- a/def.go
+++ b/def.go
@@ -4,8 +4,6 @@ import (
 	"fmt"
 	"go/ast"
 	"go/types"
-
-	"golang.org/x/tools/go/loader"
 )
 
 // unsealedError corresponds to a declared sum type whose interface is not
@@ -53,11 +51,11 @@ type sumTypeDef struct {
 // findSumTypeDefs attempts to find a Go type definition for each of the given
 // sum type declarations. If no such sum type definition could be found for
 // any of the given declarations, then an error is returned.
-func findSumTypeDefs(prog *loader.Program, decls []sumTypeDecl) ([]sumTypeDef, []error) {
+func findSumTypeDefs(decls []sumTypeDecl) ([]sumTypeDef, []error) {
 	var defs []sumTypeDef
 	var errs []error
 	for _, decl := range decls {
-		def, err := newSumTypeDef(decl.PackageInfo.Pkg, decl)
+		def, err := newSumTypeDef(decl.Package.Types, decl)
 		if err != nil {
 			errs = append(errs, err)
 			continue

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,6 @@
+module github.com/BurntSushi/go-sumtype
+
+require (
+	github.com/stretchr/testify v1.3.0
+	golang.org/x/tools v0.0.0-20190221204921-83362c3779f5
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,15 @@
+github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0Q=
+github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
+golang.org/x/net v0.0.0-20180724234803-3673e40ba225/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
+golang.org/x/net v0.0.0-20190213061140-3a22650c66bd/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
+golang.org/x/sync v0.0.0-20181108010431-42b317875d0f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
+golang.org/x/tools v0.0.0-20190221204921-83362c3779f5 h1:ev5exjGDsOo0NPTB0qdCcE53BfWl1IICJlhgXgfT9fM=
+golang.org/x/tools v0.0.0-20190221204921-83362c3779f5/go.mod h1:9Yl7xja0Znq3iFh3HoIrodX9oNMXvdceNzlUR8zjMvY=
+google.golang.org/appengine v1.4.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7/EB5XEv4=

--- a/help_test.go
+++ b/help_test.go
@@ -6,10 +6,10 @@ import (
 	"path/filepath"
 	"testing"
 
-	"golang.org/x/tools/go/loader"
+	"golang.org/x/tools/go/packages"
 )
 
-func setupPackage(t *testing.T, code string) (string, *loader.Program) {
+func setupPackages(t *testing.T, code string) (string, []*packages.Package) {
 	tmpdir, err := ioutil.TempDir("", "go-test-sumtype-")
 	if err != nil {
 		t.Fatal(err)
@@ -18,11 +18,11 @@ func setupPackage(t *testing.T, code string) (string, *loader.Program) {
 	if err := ioutil.WriteFile(srcPath, []byte(code), 0666); err != nil {
 		t.Fatal(err)
 	}
-	prog, err := tycheckAll([]string{srcPath})
+	pkgs, err := tycheckAll([]string{srcPath})
 	if err != nil {
 		t.Fatal(err)
 	}
-	return tmpdir, prog
+	return tmpdir, pkgs
 }
 
 func teardownPackage(t *testing.T, dir string) {


### PR DESCRIPTION
This PR adds support for running this tool against Go modules.

With some of the new niceties in https://godoc.org/golang.org/x/tools/go/loader there may be some opportunities for further cleanup, but I've left that alone in this PR.

Testing on my machine, this looks to now be about twice as fast!

Closes https://github.com/BurntSushi/go-sumtype/issues/8