### PR TITLE
check: fix false positive when an interface implements a sum type

### DIFF
--- a/def.go
+++ b/def.go
@@ -107,6 +107,10 @@ func newSumTypeDef(pkg *types.Package, decl sumTypeDecl) (*sumTypeDef, error) {
 		if types.Identical(ty.Underlying(), iface) {
 			continue
 		}
+		_, ok = ty.Underlying().(*types.Interface)
+		if ok {
+			continue
+		}
 		if types.Implements(ty, iface) || types.Implements(types.NewPointer(ty), iface) {
 			def.Variants = append(def.Variants, obj)
 		}
@@ -130,6 +134,11 @@ func (def *sumTypeDef) missing(tys []types.Type) []types.Object {
 			ty = indirect(ty)
 			if types.Identical(varty, ty) {
 				found = true
+			}
+			if iface, ok := ty.Underlying().(*types.Interface); ok {
+				if types.Implements(varty, iface) || types.Implements(types.NewPointer(varty), iface) {
+					found = true
+				}
 			}
 		}
 		if !found {


### PR DESCRIPTION
Sometimes it is possible for a sum type interface to be implemented by
another interface. For example, we have a sum type called T including
3 variants, A, B, C. We also have an U interface embedding T and thus
implementing T. Assuming that B and C implement U, a type switch
statement can be considered exhaustive if all of A, B, C are listed.
It should also be considered exhaustive if only A and U are listed.

However, go-sumtype does not distinguish between concrete and interface
types. It fails in both cases, requiring all of A, B, C, U to be listed.
It is unlikely to code to be written in this way. U already covers B and
C, and it is unnecessary to list them in a type switch statement. This
commit fixes the problem by handling interfaces specially.

Closes: https://github.com/BurntSushi/go-sumtype/issues/1
Closes: https://github.com/BurntSushi/go-sumtype/issues/3